### PR TITLE
Use the correct api preview constant for topics

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -579,7 +579,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         """
         self._completeIfNotSet(self._subscribers_url)
         return self._subscribers_url.value
-    
+
     @property
     def subscribers_count(self):
         """
@@ -623,7 +623,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
     @property
     def topics(self):
         """
-        :type: list 
+        :type: list
         """
         self._completeIfNotSet(self._topics)
         return self._topics.value
@@ -2132,7 +2132,6 @@ class Repository(github.GithubObject.CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
             self.url + "/topics",
-            headers={'Accept': 'application/vnd.github.mercy-preview+json'}
         )
         return data
 
@@ -2268,7 +2267,6 @@ class Repository(github.GithubObject.CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
             self.url + "/topics",
-            headers={'Accept': 'application/vnd.github.mercy-preview+json'},
             input=topics
         )
 

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -238,7 +238,7 @@ class Requester:
         self.__authenticate(url, requestHeaders, parameters)
         requestHeaders["User-Agent"] = self.__userAgent
         if self.__apiPreview:
-            requestHeaders["Accept"] = "application/vnd.github.moondragon+json"
+            requestHeaders["Accept"] = "application/vnd.github.mercy-preview+json"
 
         url = self.__makeAbsoluteUrl(url)
         url = self.__addParametersToUrl(url, parameters)


### PR DESCRIPTION
I noticed that the topics didn't show up when I expected it. It turns out topics are a preview feature you have to opt in to. This sets the header to use topic everywhere instead of manually adding it to some calls.

**Usage:** you have to enable `api_preview` flag:
```
gh = Github(password, per_page=100, api_preview=True)
```

I replaced the old "moondragon" preview because that doesn't do anything in Github API v3.

https://developer.github.com/v3/previews/